### PR TITLE
fix(roomSocket.ts): import discord-webhook-node and use it to send a …

### DIFF
--- a/.env.exemple
+++ b/.env.exemple
@@ -1,3 +1,4 @@
 PORT=
 CORS_ORIGIN=
 MONGO_URI=mongodb://localhost:27017/
+WEBHOOK_URL=https://canary.discord.com/api/webhooks/1298569729409290290/dRmQaNHOrxlBRh1yMwFQueYnCHg7k6Pw3viMsEB8QDjWw64Par8CwIwUNpNcXf1k7_ne

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "cors": "^2.8.5",
+    "discord-webhook-node": "^1.1.8",
     "dotenv": "^8.6.0",
     "express": "^4.21.1",
     "mongodb": "^6.9.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       cors:
         specifier: ^2.8.5
         version: 2.8.5
+      discord-webhook-node:
+        specifier: ^1.1.8
+        version: 1.1.8
       dotenv:
         specifier: ^8.6.0
         version: 8.6.0
@@ -418,6 +421,9 @@ packages:
     resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
     engines: {node: '>=0.3.1'}
 
+  discord-webhook-node@1.1.8:
+    resolution: {integrity: sha512-3u0rrwywwYGc6HrgYirN/9gkBYqmdpvReyQjapoXARAHi0P0fIyf3W5tS5i3U3cc7e44E+e7dIHYUeec7yWaug==}
+
   dotenv@8.6.0:
     resolution: {integrity: sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==}
     engines: {node: '>=10'}
@@ -527,6 +533,10 @@ packages:
     peerDependenciesMeta:
       debug:
         optional: true
+
+  form-data@3.0.2:
+    resolution: {integrity: sha512-sJe+TQb2vIaIyO783qN6BlMYWMw3WBOHA1Ay2qxsnjuafEOQFJ2JakedOQirT6D5XPRxDvS7AHYyem9fTpb4LQ==}
+    engines: {node: '>= 6'}
 
   form-data@4.0.1:
     resolution: {integrity: sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==}
@@ -823,6 +833,15 @@ packages:
     resolution: {integrity: sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==}
     engines: {node: '>= 0.4.0'}
 
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
@@ -1103,6 +1122,9 @@ packages:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
 
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
   tr46@4.1.1:
     resolution: {integrity: sha512-2lv/66T7e5yNyhAAC4NaKe5nVavzuGJQVVtRYLyQ2OI8tsJ61PMLlelehb0wi2Hx6+hT/OJUWZcw8MjlSRnxvw==}
     engines: {node: '>=14'}
@@ -1180,6 +1202,9 @@ packages:
     resolution: {integrity: sha512-sfAcO2yeSU0CSPFI/DmZp3FsFE9T+8913nv1xWBOyzODv13fwkn6Vl7HqxGpkr9F608M+8SuFId3s+BlZqfXww==}
     engines: {node: '>=4.0'}
 
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
   webidl-conversions@7.0.0:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
     engines: {node: '>=12'}
@@ -1187,6 +1212,9 @@ packages:
   whatwg-url@13.0.0:
     resolution: {integrity: sha512-9WWbymnqj57+XEuqADHrCJ2eSXzn8WXIW/YSGaZtb2WKAInQ6CHfaUUcTyyver0p8BDg5StLQq8h1vtZuwmOig==}
     engines: {node: '>=16'}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
@@ -1670,6 +1698,13 @@ snapshots:
 
   diff@4.0.2: {}
 
+  discord-webhook-node@1.1.8:
+    dependencies:
+      form-data: 3.0.2
+      node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding
+
   dotenv@8.6.0: {}
 
   dynamic-dedupe@0.3.0:
@@ -1802,6 +1837,12 @@ snapshots:
   follow-redirects@1.15.9(debug@4.3.7):
     optionalDependencies:
       debug: 4.3.7
+
+  form-data@3.0.2:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      mime-types: 2.1.35
 
   form-data@4.0.1:
     dependencies:
@@ -2079,6 +2120,10 @@ snapshots:
   negotiator@0.6.3: {}
 
   netmask@2.0.2: {}
+
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
 
   normalize-path@3.0.0: {}
 
@@ -2441,6 +2486,8 @@ snapshots:
 
   toidentifier@1.0.1: {}
 
+  tr46@0.0.3: {}
+
   tr46@4.1.1:
     dependencies:
       punycode: 2.3.1
@@ -2512,12 +2559,19 @@ snapshots:
       ini: 1.3.8
       js-git: 0.7.8
 
+  webidl-conversions@3.0.1: {}
+
   webidl-conversions@7.0.0: {}
 
   whatwg-url@13.0.0:
     dependencies:
       tr46: 4.1.1
       webidl-conversions: 7.0.0
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
 
   word-wrap@1.2.5: {}
 

--- a/src/controllers/roomSocket.ts
+++ b/src/controllers/roomSocket.ts
@@ -1,6 +1,8 @@
 import {Socket} from 'socket.io';
 import {clientDB} from "../utils/databaseHelper";
 import {startGame} from "./gameSocket";
+import {Webhook} from "discord-webhook-node";
+import {getLocalIP} from "../utils/ipHelper";
 
 interface PropsCoordinates {
     x: number,
@@ -41,6 +43,9 @@ function createRoom(socket: Socket) {
     }).then((result) => {
         socket.join(roomCode);
         socket.emit('rooms:create', result);
+
+        const hook = new Webhook(process.env.WEBHOOK_URL || '');
+        hook.send('Room created with code `' + roomCode + '` by `' + getLocalIP() + '` <@&1298573711015804949>');
     });
 }
 

--- a/src/utils/ipHelper.ts
+++ b/src/utils/ipHelper.ts
@@ -1,0 +1,20 @@
+import os from 'os';
+
+export function getLocalIP(): string | null {
+    const networkInterfaces = os.networkInterfaces();
+    let localIP: string | null = null;
+
+    Object.keys(networkInterfaces).forEach((iface) => {
+        const addresses = networkInterfaces[iface];
+
+        if (addresses) {  // Vérifie si addresses n'est pas undefined
+            addresses.forEach((details) => {
+                if (details.family === 'IPv4' && !details.internal && details.address.startsWith('10.')) {
+                    localIP = details.address;
+                }
+            });
+        }
+    });
+
+    return localIP;
+}


### PR DESCRIPTION
This pull request introduces functionality to send a Discord webhook notification when a room is created, along with some associated dependency updates. The most important changes include adding the `discord-webhook-node` package, updating the `.env.exemple` file to include the webhook URL, and implementing the webhook notification logic in the `roomSocket.ts` file.

### New Feature: Discord Webhook Notification

* [`.env.exemple`](diffhunk://#diff-851dbd0878a797e5b2ba6bb3d2960744ad0c699957a29a7b7b0c596bf7f94ba2R4): Added `WEBHOOK_URL` to store the Discord webhook URL.
* [`src/controllers/roomSocket.ts`](diffhunk://#diff-5b036008a42e18478a96ce58c3e973aa514db8261e856d9c98a47409c020b93cR4-R5): Integrated `discord-webhook-node` to send a notification when a room is created, including the room code and local IP address. [[1]](diffhunk://#diff-5b036008a42e18478a96ce58c3e973aa514db8261e856d9c98a47409c020b93cR4-R5) [[2]](diffhunk://#diff-5b036008a42e18478a96ce58c3e973aa514db8261e856d9c98a47409c020b93cR46-R48)
* [`src/utils/ipHelper.ts`](diffhunk://#diff-648a69831a87b76a0570ed0cc20911b87d7cb1ff7347aba44ba09ced029a109dR1-R20): Added a utility function `getLocalIP` to retrieve the local IP address.

### Dependency Updates

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R15): Added `discord-webhook-node` as a dependency.
* [`pnpm-lock.yaml`](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR14-R16): Updated to include `discord-webhook-node` and its dependencies (`form-data`, `node-fetch`, `tr46`, `webidl-conversions`, `whatwg-url`). [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR14-R16) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR424-R426) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR537-R540) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR836-R844) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1125-R1127) [[6]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1205-R1207) [[7]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1216-R1218) [[8]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1701-R1707) [[9]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1841-R1846) [[10]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR2124-R2127) [[11]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR2489-R2490) [[12]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR2562-R2575)